### PR TITLE
Expand library to include camel case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Other stuff
+.DS_Store
+.AppleDouble
+.LSOverride
+.idea
+.vscode
+coverage.out

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/danielchatfield/gogenutils
+
+go 1.18
+
+require github.com/stretchr/testify v1.8.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/utils.go
+++ b/utils.go
@@ -28,9 +28,25 @@ func JSONFieldName(s string) string {
 	return s
 }
 
+// CamelCase returns the camelCase version of a text string
+func CamelCase(s string) string {
+	return camelAndPascalCase(s, true)
+}
+
 // PascalCase returns the PascalCase version of a text string
 func PascalCase(s string) string {
+	return camelAndPascalCase(s, false)
+}
+
+func camelAndPascalCase(s string, isCamel bool) string {
 	prev := ' '
+
+	// For camel case we initialise the prev to be a non
+	// seperator so the first letter is lowercase
+	if isCamel {
+		prev = '0'
+	}
+
 	s = strings.Map(
 		func(r rune) rune {
 			if isSeparator(prev) {
@@ -42,7 +58,10 @@ func PascalCase(s string) string {
 		},
 		s)
 
-	return strings.Replace(s, " ", "", -1)
+	s = strings.Replace(s, " ", "", -1)
+	s = strings.Replace(s, "_", "", -1)
+
+	return s
 }
 
 // SnakeCase returns the snake_case version of a text string

--- a/utils_test.go
+++ b/utils_test.go
@@ -71,6 +71,10 @@ func TestPascalCase(t *testing.T) {
 			In:  "this is a test",
 			Out: "ThisIsATest",
 		},
+		{
+			In:  "this_is_a_test",
+			Out: "ThisIsATest",
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -78,6 +82,30 @@ func TestPascalCase(t *testing.T) {
 
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, testcase.Out, PascalCase(testcase.In))
+		})
+	}
+}
+
+func TestCamelCase(t *testing.T) {
+	var testcases = []struct {
+		In  string
+		Out string
+	}{
+		{
+			In:  "this is a test",
+			Out: "thisIsATest",
+		},
+		{
+			In:  "this_is_a_test",
+			Out: "thisIsATest",
+		},
+	}
+
+	for _, testcase := range testcases {
+		name := testcase.In
+
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testcase.Out, CamelCase(testcase.In))
 		})
 	}
 }


### PR DESCRIPTION
Adds a `CamelCase` helper as well as improving how `PascalCase` deals with underscores.